### PR TITLE
fix(apigw): register HttpMethod in logging serialization context

### DIFF
--- a/src/Functions/Goa.Functions.ApiGateway/LoggingSerializationContext.cs
+++ b/src/Functions/Goa.Functions.ApiGateway/LoggingSerializationContext.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using System.Net.Http;
 using System.Text.Json.Serialization;
 
 namespace Goa.Functions.ApiGateway;
@@ -21,6 +22,7 @@ namespace Goa.Functions.ApiGateway;
 [JsonSerializable(typeof(short))]
 [JsonSerializable(typeof(int))]
 [JsonSerializable(typeof(long))]
+[JsonSerializable(typeof(HttpMethod))]
 [JsonSerializable(typeof(Guid))]
 [JsonSerializable(typeof(DateTime))]
 [JsonSerializable(typeof(HostString))]


### PR DESCRIPTION
## Summary
`Microsoft.Extensions.Http` logs the request method when an outbound `HttpClient` request starts (`"Start processing HTTP request {HttpMethod} {Uri}"`). The boxed `HttpMethod` reached the JSON logger and `DictionaryJsonConverter` threw because the ApiGateway `LoggingSerializationContext` had no type info for it, producing recurring errors:

> An error occurred while writing to logger(s). (type: System.Net.Http.HttpMethod is not supported by LoggingSerializationContext.)

This registers `HttpMethod` in the ApiGateway context, mirroring the Core logging context.

## Notes
- Serialises as `"httpMethod": { "method": "GET" }` (object form).
- The converter still throws on other unregistered types a third-party library might log (`Uri`, `HttpStatusCode`, `TimeSpan`, …). A graceful `ToString()` fallback in `DictionaryJsonConverter` would close that whole class — out of scope here by request.

## Testing
- `dotnet build` on `Goa.Functions.ApiGateway` — 0 errors, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)