### PR TITLE
fix(dynamo-gen): robust DateTime/DateTimeOffset check for [UnixTimest…

### DIFF
--- a/src/Clients/Goa.Clients.Dynamo.Generator/Attributes/AttributeHandlerRegistry.cs
+++ b/src/Clients/Goa.Clients.Dynamo.Generator/Attributes/AttributeHandlerRegistry.cs
@@ -52,13 +52,33 @@ public class AttributeHandlerRegistry
         if (attributeInfo is UnixTimestampAttributeInfo && symbol is IPropertySymbol property)
         {
             var type = property.Type;
-            if (type is INamedTypeSymbol { IsGenericType: true } nullable)
-                type = nullable.TypeArguments[0];
 
-            return type.Name is nameof(DateTime) or nameof(DateTimeOffset);
+            // Only unwrap genuine Nullable<T>, not arbitrary generics such as List<DateTime>.
+            if (type is INamedTypeSymbol named &&
+                named.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T &&
+                named.TypeArguments.Length == 1)
+            {
+                type = named.TypeArguments[0];
+            }
+
+            return IsDateTimeType(type);
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// Determines whether the given type is System.DateTime or System.DateTimeOffset
+    /// using robust symbol identity rather than brittle name comparisons.
+    /// </summary>
+    private static bool IsDateTimeType(ITypeSymbol type)
+    {
+        if (type.SpecialType == SpecialType.System_DateTime)
+            return true;
+
+        // DateTimeOffset has no SpecialType, so identify it by its fully-qualified name.
+        return type.Name == nameof(DateTimeOffset)
+               && type.ContainingNamespace?.ToDisplayString() == "System";
     }
 
     /// <summary>

--- a/tests/Clients/Goa.Clients.Dynamo.Generator.Tests/Attributes/AttributeHandlerRegistryTests.cs
+++ b/tests/Clients/Goa.Clients.Dynamo.Generator.Tests/Attributes/AttributeHandlerRegistryTests.cs
@@ -297,6 +297,74 @@ public class AttributeHandlerRegistryTests
     }
 
     [Test]
+    public async Task ProcessAttributes_UnixTimestampOnNullableDateTimeProperty_ShouldBeIncluded()
+    {
+        // Arrange: [UnixTimestamp] on DateTime? must be unwrapped before the compatibility check
+        // and kept, just like the non-nullable variant.
+        var registry = new AttributeHandlerRegistry();
+        var mockHandler = new Mock<IAttributeHandler>();
+        var mockAttributeData = MockSymbolFactory.CreateAttributeData("Goa.Clients.Dynamo.UnixTimestampAttribute");
+        var unixTimestampInfo = new UnixTimestampAttributeInfo
+        {
+            AttributeData = mockAttributeData,
+            AttributeTypeName = "Goa.Clients.Dynamo.UnixTimestampAttribute",
+            Format = Generator.Models.UnixTimestampFormat.Seconds
+        };
+
+        mockHandler.Setup(h => h.CanHandle(It.IsAny<AttributeData>())).Returns(true);
+        mockHandler.Setup(h => h.ParseAttribute(It.IsAny<AttributeData>())).Returns(unixTimestampInfo);
+
+        registry.RegisterHandler(mockHandler.Object);
+
+        // Create a property symbol with DateTime? (Nullable<DateTime>) type
+        var nullableDateTime = MockSymbolFactory.CreateNullableType(MockSymbolFactory.PrimitiveTypes.DateTime).Object;
+        var propertySymbol = MockSymbolFactory.CreatePropertySymbol("ExpiresAt", nullableDateTime);
+        propertySymbol.Setup(p => p.GetAttributes())
+            .Returns(System.Collections.Immutable.ImmutableArray.Create(mockAttributeData));
+
+        // Act
+        var attributes = registry.ProcessAttributes(propertySymbol.Object);
+
+        // Assert: UnixTimestamp on DateTime? should be kept
+        await Assert.That(attributes).Count().IsEqualTo(1);
+        await Assert.That(attributes[0]).IsTypeOf<UnixTimestampAttributeInfo>();
+    }
+
+    [Test]
+    public async Task ProcessAttributes_UnixTimestampOnNullableDateTimeOffsetProperty_ShouldBeIncluded()
+    {
+        // Arrange: [UnixTimestamp] on DateTimeOffset? must be unwrapped before the compatibility check
+        // and kept, just like the non-nullable variant.
+        var registry = new AttributeHandlerRegistry();
+        var mockHandler = new Mock<IAttributeHandler>();
+        var mockAttributeData = MockSymbolFactory.CreateAttributeData("Goa.Clients.Dynamo.UnixTimestampAttribute");
+        var unixTimestampInfo = new UnixTimestampAttributeInfo
+        {
+            AttributeData = mockAttributeData,
+            AttributeTypeName = "Goa.Clients.Dynamo.UnixTimestampAttribute",
+            Format = Generator.Models.UnixTimestampFormat.Seconds
+        };
+
+        mockHandler.Setup(h => h.CanHandle(It.IsAny<AttributeData>())).Returns(true);
+        mockHandler.Setup(h => h.ParseAttribute(It.IsAny<AttributeData>())).Returns(unixTimestampInfo);
+
+        registry.RegisterHandler(mockHandler.Object);
+
+        // Create a property symbol with DateTimeOffset? (Nullable<DateTimeOffset>) type
+        var nullableDateTimeOffset = MockSymbolFactory.CreateNullableType(MockSymbolFactory.PrimitiveTypes.DateTimeOffset).Object;
+        var propertySymbol = MockSymbolFactory.CreatePropertySymbol("UpdatedAt", nullableDateTimeOffset);
+        propertySymbol.Setup(p => p.GetAttributes())
+            .Returns(System.Collections.Immutable.ImmutableArray.Create(mockAttributeData));
+
+        // Act
+        var attributes = registry.ProcessAttributes(propertySymbol.Object);
+
+        // Assert: UnixTimestamp on DateTimeOffset? should be kept
+        await Assert.That(attributes).Count().IsEqualTo(1);
+        await Assert.That(attributes[0]).IsTypeOf<UnixTimestampAttributeInfo>();
+    }
+
+    [Test]
     public async Task ProcessAttributes_HandlerReturnsNull_ShouldNotAddToResults()
     {
         // Arrange


### PR DESCRIPTION
…amp] filter

Use SpecialType.System_DateTime and a namespace-qualified DateTimeOffset check instead of brittle type.Name comparisons, and only unwrap genuine Nullable<T> (via OriginalDefinition.SpecialType) rather than any generic, so [UnixTimestamp] on List<DateTime> or a custom DateTime type is no longer erroneously accepted. Add nullable DateTime/DateTimeOffset tests.

## Checklist

- [ ] Tests added/updated and passing (Docker required for integration tests)
- [ ] Tested to be compatible with Native AOT compilation
- [ ] Documentation updated for new public APIs
- [ ] Self-review completed