### PR TITLE
fix(dynamo-gen): use robust DateTime check in UnixTimestampTypeHandler

### DIFF
--- a/src/Clients/Goa.Clients.Dynamo.Generator/Attributes/AttributeHandlerRegistry.cs
+++ b/src/Clients/Goa.Clients.Dynamo.Generator/Attributes/AttributeHandlerRegistry.cs
@@ -61,24 +61,10 @@ public class AttributeHandlerRegistry
                 type = named.TypeArguments[0];
             }
 
-            return IsDateTimeType(type);
+            return type.IsDateTimeOrDateTimeOffset();
         }
 
         return true;
-    }
-
-    /// <summary>
-    /// Determines whether the given type is System.DateTime or System.DateTimeOffset
-    /// using robust symbol identity rather than brittle name comparisons.
-    /// </summary>
-    private static bool IsDateTimeType(ITypeSymbol type)
-    {
-        if (type.SpecialType == SpecialType.System_DateTime)
-            return true;
-
-        // DateTimeOffset has no SpecialType, so identify it by its fully-qualified name.
-        return type.Name == nameof(DateTimeOffset)
-               && type.ContainingNamespace?.ToDisplayString() == "System";
     }
 
     /// <summary>

--- a/src/Clients/Goa.Clients.Dynamo.Generator/Models/TypeSymbolExtensions.cs
+++ b/src/Clients/Goa.Clients.Dynamo.Generator/Models/TypeSymbolExtensions.cs
@@ -1,0 +1,23 @@
+using Microsoft.CodeAnalysis;
+
+namespace Goa.Clients.Dynamo.Generator.Models;
+
+/// <summary>
+/// Helper extensions for inspecting Roslyn type symbols.
+/// </summary>
+internal static class TypeSymbolExtensions
+{
+    /// <summary>
+    /// Determines whether the given type is System.DateTime or System.DateTimeOffset
+    /// using robust symbol identity rather than brittle name comparisons.
+    /// </summary>
+    public static bool IsDateTimeOrDateTimeOffset(this ITypeSymbol type)
+    {
+        if (type.SpecialType == SpecialType.System_DateTime)
+            return true;
+
+        // DateTimeOffset has no SpecialType, so identify it by its fully-qualified name.
+        return type.Name == nameof(DateTimeOffset)
+               && type.ContainingNamespace?.ToDisplayString() == "System";
+    }
+}

--- a/src/Clients/Goa.Clients.Dynamo.Generator/TypeHandlers/UnixTimestampTypeHandler.cs
+++ b/src/Clients/Goa.Clients.Dynamo.Generator/TypeHandlers/UnixTimestampTypeHandler.cs
@@ -13,9 +13,8 @@ public class UnixTimestampTypeHandler : ITypeHandler
     {
         var underlyingType = propertyInfo.UnderlyingType;
         var hasUnixTimestamp = propertyInfo.Attributes.Any(a => a is UnixTimestampAttributeInfo);
-        
-        return hasUnixTimestamp && 
-               (underlyingType.Name == nameof(DateTime) || underlyingType.Name == nameof(DateTimeOffset));
+
+        return hasUnixTimestamp && underlyingType.IsDateTimeOrDateTimeOffset();
     }
     
     public string GenerateToAttributeValue(PropertyInfo propertyInfo)

--- a/tests/Clients/Goa.Clients.Dynamo.Generator.Tests/TypeHandlers/UnixTimestampTypeHandlerTests.cs
+++ b/tests/Clients/Goa.Clients.Dynamo.Generator.Tests/TypeHandlers/UnixTimestampTypeHandlerTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.CodeAnalysis;
 using Goa.Clients.Dynamo.Generator.TypeHandlers;
 using Goa.Clients.Dynamo.Generator.Tests.Helpers;
 
@@ -80,6 +81,33 @@ public class UnixTimestampTypeHandlerTests
         var propertyInfo = TestModelBuilders.CreateUnixTimestampPropertyInfo(
             "InvalidProperty",
             MockSymbolFactory.PrimitiveTypes.String,
+            isNullable: false,
+            format: Models.UnixTimestampFormat.Seconds
+        );
+
+        // Act
+        var result = _handler.CanHandle(propertyInfo);
+
+        // Assert
+        await Assert.That(result)
+            .IsFalse();
+    }
+
+    [Test]
+    public async Task CanHandle_WithUserDefinedTypeNamedDateTime_ShouldReturnFalse()
+    {
+        // Arrange: a user-defined type named "DateTime" outside the System namespace
+        // must not be treated as System.DateTime. The robust symbol-based check relies
+        // on SpecialType/namespace rather than the type name alone.
+        var spoofedDateTime = MockSymbolFactory.CreateNamedTypeSymbol(
+            "DateTime",
+            "MyApp.DateTime",
+            namespaceName: "MyApp",
+            specialType: SpecialType.None).Object;
+
+        var propertyInfo = TestModelBuilders.CreateUnixTimestampPropertyInfo(
+            "FakeTimestamp",
+            spoofedDateTime,
             isNullable: false,
             format: Models.UnixTimestampFormat.Seconds
         );


### PR DESCRIPTION
## Context

Follow-up to #74. That PR moved `AttributeHandlerRegistry` to a robust, symbol-based DateTime/DateTimeOffset check, but `UnixTimestampTypeHandler.CanHandle` was left on the brittle name-only comparison:

```csharp
underlyingType.Name == nameof(DateTime) || underlyingType.Name == nameof(DateTimeOffset)
```

A user-defined type named `DateTime` (or `DateTimeOffset`) outside the `System` namespace would be mistaken for the BCL type.

## Change

- Extract the robust check into a shared `ITypeSymbol.IsDateTimeOrDateTimeOffset()` extension (`SpecialType.System_DateTime` for `DateTime`; type name + `System` namespace via `ToDisplayString()` for `DateTimeOffset`, which has no `SpecialType`).
- Use it in both `UnixTimestampTypeHandler.CanHandle` and `AttributeHandlerRegistry` — single source of truth, removes the duplicated namespace logic.

## Scope notes

Deliberately left untouched (out of scope of this finding):
- `UnixTimestampTypeHandler.GenerateFromDynamoRecord` name checks — they run only after `CanHandle` already confirmed the type, so they select a branch rather than gate.
- `DateTimeTypeHandler` / `UnixTimestampAttributeHandler` name-only checks — pre-existing, unrelated to this finding. The new extension is available to tighten them later.

## Validation

- `dotnet build` of the generator: clean (0 warnings/errors).
- `dotnet test`: **359 passed**, 0 failed — including a new regression test that builds a type named `DateTime` outside `System` and asserts `CanHandle` returns `false` (would have returned `true` under the old check).