### PR TITLE
ci: use NuGet Trusted Publishing (OIDC) instead of API key

### DIFF
--- a/.github/workflows/nuget-release.yml
+++ b/.github/workflows/nuget-release.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # enable GitHub OIDC token issuance for Trusted Publishing
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
@@ -58,9 +60,15 @@ jobs:
     - name: List generated packages
       run: find artifacts/package/release -name "*.nupkg" -type f
 
+    - name: NuGet login (OIDC -> short-lived API key)
+      uses: NuGet/login@v1
+      id: login
+      with:
+        user: ${{ secrets.NUGET_USER }}
+
     - name: Publish to NuGet
       run: |
         for package in artifacts/package/release/*.nupkg; do
           echo "Publishing $package"
-          dotnet nuget push "$package" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+          dotnet nuget push "$package" --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
         done


### PR DESCRIPTION
## What

Switches the NuGet release workflow from a long-lived `NUGET_API_KEY` secret to **Trusted Publishing** using GitHub OIDC.

When the workflow runs, GitHub issues a short-lived OIDC token; the `NuGet/login` action exchanges it with nuget.org for a temporary API key (valid 1 hour) that `dotnet nuget push` then uses. No static secret to store, rotate, or leak.

## Changes

- Add `permissions: id-token: write` to the `publish` job so GitHub will issue an OIDC token.
- Add a `NuGet/login@v1` step that mints a short-lived API key, authenticating as `${{ secrets.NUGET_USER }}`.
- `dotnet nuget push` now uses `${{ steps.login.outputs.NUGET_API_KEY }}` instead of `${{ secrets.NUGET_API_KEY }}`.

## Required manual setup before this can publish

1. **Create a Trusted Publishing policy on nuget.org** — log in → username menu → **Trusted Publishing** → add policy:
   - Repository Owner: `im5tu`
   - Repository: `goa`
   - Workflow File: `nuget-release.yml` (filename only, no path)
   - Environment: leave empty (the workflow uses no GitHub environment)
2. **Add a `NUGET_USER` repo secret** set to your nuget.org **profile/username** (not your email).
3. After it works, the old `NUGET_API_KEY` secret can be deleted.

> Note: for a private repo the policy is temporarily active for 7 days until the first successful publish locks it to the repo/owner IDs. `goa` is public, so it activates immediately.

Reference: https://learn.microsoft.com/nuget/nuget-org/trusted-publishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
